### PR TITLE
Redesign /challenges to use objects for category and type

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -19,9 +19,9 @@ traits:
   displayName: Challenges
   type: [
     crud: {
-      filterableProperties: "title,endTime,type,categoryId",
-      sortableProperties: "title,endTime,type,categoryId",
-      includableRelations: "category"
+      filterableProperties: "title,endTime,challengeType.identifier,challengeCategory.identifier",
+      sortableProperties: "title,endTime,challengeType.identifier,challengeCategory.identifier",
+      includableRelations: "challengeCategory,challengeType"
     }
   ]
   post:

--- a/examples/challengeRequest.raml
+++ b/examples/challengeRequest.raml
@@ -2,5 +2,5 @@ title: "FIFA 18 Season 1"
 description: "The winter challenge inside Jamit Labs."
 password: "secret"
 endTime: "2019-10-02T15:00:00Z"
-type: "season"
-categoryId: "4"
+challengeType: {name: "Season", identifier: "3"}
+challengeCategory: { name: "Category", identifier: "47" }

--- a/examples/challengeResponse.raml
+++ b/examples/challengeResponse.raml
@@ -1,6 +1,7 @@
+identifier: "15"
 title: "FIFA 18 Season 1"
 description: "The winter challenge inside Jamit Labs."
 hasPassword: true
 endTime: "2019-10-02T15:00:00Z"
-type: "season"
-category: { typeName: "Category", identifier: "47" }
+challengeType: {name: "Season", identifier: "3"}
+challengeCategory: { name: "Category", identifier: "47" }

--- a/types/allTypes.raml
+++ b/types/allTypes.raml
@@ -1,8 +1,5 @@
 Base:
   type: object
-  properties:
-    typeName: string
-    identifier: string
 Error:
   type: object
   properties:
@@ -11,28 +8,32 @@ Error:
 Errors:
   type: Error[]
   minItems: 1
-Category:
+ChallengeType:
   type: Base
   properties:
     name: string
+    identifier: integer
+ChallengeCategory:
+  type: Base
+  properties:
+    name: string
+    identifier: integer
 Challenge:
   type: Base
   properties:
     title: string
     description?: string
     endTime?: datetime
-    type:
-      enum: [ tournament, season, open ]
+    challengeType: ChallengeType
+    challengeCategory: ChallengeCategory
 ChallengeRequest:
   type: Challenge
   properties:
     password?: string
-    categoryId: string
   example: !include ../examples/challengeRequest.raml
 ChallengeResponse:
   type: Challenge
   properties:
+    identifier: integer
     hasPassword: boolean
-    matchesCount: integer
-    category: Base
   example: !include ../examples/challengeResponse.raml


### PR DESCRIPTION
This is an object based approach for uploading and receiving the category and type of a challenge.
The category itself is not defined in the data model v. 0.3 but I think it's crucial for challenges.

Let me know if you think this is a good idea or if we should stick to using ids for POST.

The filterable, sortable and include parameters of the api.raml are also updated. I'm not sure if this change is really useful, but at least some degree of filtering should be implemented. Maybe it makes sense to use the name of a category or type too?